### PR TITLE
Update OAuth42Guard

### DIFF
--- a/transcendence-app/src/oauth42/oauth42.guard.ts
+++ b/transcendence-app/src/oauth42/oauth42.guard.ts
@@ -1,5 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { BadGatewayException, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-export class OAuth42Guard extends AuthGuard('oauth42') {}
+export class OAuth42Guard extends AuthGuard('oauth42') {
+  handleRequest(err: any, user: any) {
+    if (err || !user) {
+      throw new BadGatewayException();
+    }
+    return user;
+  }
+}


### PR DESCRIPTION
Add an override for the `handleRequest` method.

Throw `BadGatewayExeption` if an exception occurs from `OAuth42Strategy` or if the validate function returns a falsy value instead of a user.

We can remove the try/catch from `OAuth42Strategy` because this method will catch any errors.


closes #40