### PR TITLE
Create componentBook section to test and see example of components #109

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "ft_transcendence",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -2,12 +2,14 @@ import { createRoot } from 'react-dom/client';
 import React from 'react';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
-import { Chat, Landing, Play, Users } from './pages';
+import { Chat, Landing, Play, Users, ComponentsBook } from './pages';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { CHAT_URL, PLAY_URL, USERS_URL } from './shared/urls';
+import { CHAT_URL, PLAY_URL, USERS_URL, COMPONENTS_BOOK_URL } from './shared/urls';
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
+const developmentMode = process.env.NODE_ENV === 'development';
+
 root.render(
   <React.StrictMode>
     <BrowserRouter>
@@ -16,6 +18,7 @@ root.render(
         <Route path={USERS_URL} element={<Users />} />
         <Route path={PLAY_URL} element={<Play />} />
         <Route path={CHAT_URL} element={<Chat />} />
+        { developmentMode && <Route path={COMPONENTS_BOOK_URL} element={<ComponentsBook />} />}
       </Routes>
     </BrowserRouter>
   </React.StrictMode>,

--- a/webapp/src/pages/ComponentsBook/BookSection.tsx
+++ b/webapp/src/pages/ComponentsBook/BookSection.tsx
@@ -1,0 +1,39 @@
+import {
+  Text,
+  TextVariant,
+  TextWeight,
+  TextColor,
+} from '../../shared/components';
+
+type singleOrMultipleChildren = React.ReactElement | React.ReactElement[];
+
+type bookSectionProps = {
+  title: string;
+  children: singleOrMultipleChildren;
+};
+
+const wrapExample = (elements: singleOrMultipleChildren) =>
+  Array.isArray(elements) ? (
+    elements.map((el) => (
+      <div className="components-book__section__example-wrapper">{el}</div>
+    ))
+  ) : (
+    <div className="components-book__section__example-wrapper">{elements}</div>
+  );
+
+export const BookSection = ({ title, children }: bookSectionProps) => (
+  <section className="components-book__section">
+    <div  className="components-book__section__title">
+      <Text
+        variant={TextVariant.HEADING}
+        color={TextColor.LIGHT}
+        weight={TextWeight.BOLD}
+      >
+        {` ${title}`}
+      </Text>
+    </div>
+    <div className="components-book__section__items">
+      {wrapExample(children)}
+    </div>
+  </section>
+);

--- a/webapp/src/pages/ComponentsBook/BookSection.tsx
+++ b/webapp/src/pages/ComponentsBook/BookSection.tsx
@@ -9,6 +9,7 @@ type singleOrMultipleChildren = React.ReactElement | React.ReactElement[];
 
 type bookSectionProps = {
   title: string;
+  displayVertical?: boolean;
   children: singleOrMultipleChildren;
 };
 
@@ -21,7 +22,7 @@ const wrapExample = (elements: singleOrMultipleChildren) =>
     <div className="components-book__section__example-wrapper">{elements}</div>
   );
 
-export const BookSection = ({ title, children }: bookSectionProps) => (
+export const BookSection = ({ title, displayVertical, children }: bookSectionProps) => (
   <section className="components-book__section">
     <div  className="components-book__section__title">
       <Text
@@ -32,7 +33,7 @@ export const BookSection = ({ title, children }: bookSectionProps) => (
         {` ${title}`}
       </Text>
     </div>
-    <div className="components-book__section__items">
+    <div className={`components-book__section__items${displayVertical ? '-vertical' : ''}`}>
       {wrapExample(children)}
     </div>
   </section>

--- a/webapp/src/pages/ComponentsBook/BookSection.tsx
+++ b/webapp/src/pages/ComponentsBook/BookSection.tsx
@@ -13,6 +13,11 @@ type bookSectionProps = {
   children: singleOrMultipleChildren;
 };
 
+type bookSubsectionProps = {
+  title: string;
+  children: singleOrMultipleChildren;
+};
+
 const wrapExample = (elements: singleOrMultipleChildren) =>
   Array.isArray(elements) ? (
     elements.map((el) => (
@@ -22,19 +27,40 @@ const wrapExample = (elements: singleOrMultipleChildren) =>
     <div className="components-book__section__example-wrapper">{elements}</div>
   );
 
-export const BookSection = ({ title, displayVertical, children }: bookSectionProps) => (
+export const BookSection = ({
+  title,
+  displayVertical,
+  children,
+}: bookSectionProps) => (
   <section className="components-book__section">
-    <div  className="components-book__section__title">
+    <div className="components-book__section__title">
       <Text
         variant={TextVariant.HEADING}
         color={TextColor.LIGHT}
         weight={TextWeight.BOLD}
       >
-        {` ${title}`}
+        {title}
       </Text>
     </div>
-    <div className={`components-book__section__items${displayVertical ? '-vertical' : ''}`}>
+    <div
+      className={`components-book__section__items${
+        displayVertical ? '-vertical' : ''
+      }`}
+    >
       {wrapExample(children)}
     </div>
   </section>
+);
+
+export const BookSubsection = ({ title, children }: bookSubsectionProps) => (
+  <div className="components-book__sub-section">
+    {children}
+    <Text
+      variant={TextVariant.CAPTION}
+      color={TextColor.LIGHT}
+      weight={TextWeight.REGULAR}
+    >
+      {`ℹ️​ ${title}`}
+    </Text>
+  </div>
 );

--- a/webapp/src/pages/ComponentsBook/ComponentsBook.css
+++ b/webapp/src/pages/ComponentsBook/ComponentsBook.css
@@ -22,6 +22,14 @@
   margin-bottom: 2rem;
 }
 
+.components-book__sub-section {
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
+
 .components-book__section__title {
   width: 100%;
   border: solid white;

--- a/webapp/src/pages/ComponentsBook/ComponentsBook.css
+++ b/webapp/src/pages/ComponentsBook/ComponentsBook.css
@@ -1,0 +1,44 @@
+.components-book {
+  margin: 0;
+  padding: 100px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 1rem;
+  background-color: var(--color-background);
+  color: var(--color-light);
+}
+
+.components-book__section {
+  width: 60%;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.components-book__section__title {
+  width: 100%;
+  border: solid white;
+  border-width: 0 0 0.15rem 0;
+  margin-bottom: 1.5rem;
+}
+
+.components-book__section__items {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.components-book__section__example-wrapper {
+  width: 100%;
+  margin: 0.25rem;
+}
+

--- a/webapp/src/pages/ComponentsBook/ComponentsBook.css
+++ b/webapp/src/pages/ComponentsBook/ComponentsBook.css
@@ -37,6 +37,14 @@
   justify-content: flex-start;
 }
 
+.components-book__section__items-vertical {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
+
 .components-book__section__example-wrapper {
   width: 100%;
   margin: 0.25rem;

--- a/webapp/src/pages/ComponentsBook/ComponentsBook.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsBook.tsx
@@ -1,0 +1,34 @@
+import { Text, TextColor, TextVariant, TextWeight } from '../../shared/components';
+import './ComponentsBook.css';
+import {
+  NavigationExample,
+  TextExample,
+  ButtonsExample,
+  StatusExample,
+  IconExample,
+  AvatarExample,
+  RowExample,
+  InputExample,
+} from './ComponentsExamples';
+
+export default function ComponentsBook() {
+  return (
+    <div className="components-book">
+      <Text
+        variant={TextVariant.TITLE}
+        color={TextColor.LIGHT}
+        weight={TextWeight.BOLD}
+      >
+        🎨 Components Book
+      </Text>
+      <IconExample />
+      <TextExample />
+      <StatusExample />
+      <ButtonsExample />
+      <NavigationExample />
+      <AvatarExample />
+      <RowExample />
+      <InputExample />
+    </div>
+  );
+}

--- a/webapp/src/pages/ComponentsBook/ComponentsBook.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsBook.tsx
@@ -8,7 +8,9 @@ import {
   IconExample,
   AvatarExample,
   RowExample,
+  RowsListExample,
   InputExample,
+  HeaderExample
 } from './ComponentsExamples';
 
 export default function ComponentsBook() {
@@ -26,8 +28,10 @@ export default function ComponentsBook() {
       <StatusExample />
       <ButtonsExample />
       <NavigationExample />
+      <HeaderExample />
       <AvatarExample />
       <RowExample />
+      <RowsListExample />
       <InputExample />
     </div>
   );

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/AvatarExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/AvatarExample.tsx
@@ -1,0 +1,13 @@
+import { SmallAvatar, LargeAvatar } from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+const randomAvatar = 'https://i.pravatar.cc/1000';
+
+export const AvatarExample = () => (
+  <BookSection title="Avatar component">
+    <SmallAvatar url={randomAvatar} />
+    <LargeAvatar url={randomAvatar} />
+    <SmallAvatar url={randomAvatar} status="playing" />
+    <LargeAvatar url={randomAvatar} edit status="playing" caption="level 21" />
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/ButtonsExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/ButtonsExample.tsx
@@ -1,9 +1,5 @@
-import {
-  Button,
-  ButtonVariant,
-  IconVariant,
-} from '../../../shared/components';
-import { BookSection } from '../BookSection';
+import { Button, ButtonVariant, IconVariant } from '../../../shared/components';
+import { BookSection, BookSubsection } from '../BookSection';
 
 const buttonLink = (): void => {
   window.location.href = 'http://google.com';
@@ -13,22 +9,28 @@ const buttonAction = (): void => alert('This is an alert');
 
 export const ButtonsExample = () => (
   <BookSection title="Button component">
-    <Button variant={ButtonVariant.WARNING} onClick={buttonAction}>
-      Alert
-    </Button>
-    <Button
-      variant={ButtonVariant.WARNING}
-      iconVariant={IconVariant.LOGOUT}
-      disabled
-    >
-      Logout
-    </Button>
-    <Button
-      variant={ButtonVariant.SUBMIT}
-      iconVariant={IconVariant.ARROW_FORWARD}
-      onClick={buttonLink}
-    >
-      To Google
-    </Button>
+    <BookSubsection title="Warning type">
+      <Button variant={ButtonVariant.WARNING} onClick={buttonAction}>
+        Alert
+      </Button>
+    </BookSubsection>
+    <BookSubsection title="Disabled">
+      <Button
+        variant={ButtonVariant.WARNING}
+        iconVariant={IconVariant.LOGOUT}
+        disabled
+      >
+        Logout
+      </Button>
+    </BookSubsection>
+    <BookSubsection title="Submit type with icon">
+      <Button
+        variant={ButtonVariant.SUBMIT}
+        iconVariant={IconVariant.ARROW_FORWARD}
+        onClick={buttonLink}
+      >
+        To Google
+      </Button>
+    </BookSubsection>
   </BookSection>
 );

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/ButtonsExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/ButtonsExample.tsx
@@ -1,0 +1,34 @@
+import {
+  Button,
+  ButtonVariant,
+  IconVariant,
+} from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+const buttonLink = (): void => {
+  window.location.href = 'http://google.com';
+};
+
+const buttonAction = (): void => alert('This is an alert');
+
+export const ButtonsExample = () => (
+  <BookSection title="Button component">
+    <Button variant={ButtonVariant.WARNING} onClick={buttonAction}>
+      Alert
+    </Button>
+    <Button
+      variant={ButtonVariant.WARNING}
+      iconVariant={IconVariant.LOGOUT}
+      disabled
+    >
+      Logout
+    </Button>
+    <Button
+      variant={ButtonVariant.SUBMIT}
+      iconVariant={IconVariant.ARROW_FORWARD}
+      onClick={buttonLink}
+    >
+      To Google
+    </Button>
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/HeaderExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/HeaderExample.tsx
@@ -1,0 +1,30 @@
+import { Header, IconVariant } from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+const randomAvatar = 'https://i.pravatar.cc/1000';
+const placeholderTitle = 'Header title';
+
+export const HeaderExample = () => (
+  <BookSection title="Header component" displayVertical>
+    <Header
+      navigationFigure={IconVariant.ARROW_BACK}
+      navigationUrl="/"
+      statusVariant="online"
+    >
+      {placeholderTitle}
+    </Header>
+    <Header
+      navigationFigure={randomAvatar}
+      navigationUrl="/"
+      statusVariant="playing"
+    >
+      {placeholderTitle}
+    </Header>
+    <Header navigationFigure={IconVariant.ARROW_BACK} navigationUrl="/">
+      {placeholderTitle}
+    </Header>
+    <Header navigationFigure={randomAvatar} navigationUrl="/">
+      {placeholderTitle}
+    </Header>
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/IconExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/IconExample.tsx
@@ -1,0 +1,37 @@
+import {
+  Icon,
+  IconVariant,
+  IconSize,
+} from '../../../shared/components';
+import { Color } from '../../../shared/types';
+import { BookSection } from '../BookSection';
+
+export const IconExample = () => (
+  <BookSection title="Icon component">
+    <Icon
+      variant={IconVariant.PLAY}
+      color={Color.LIGHT}
+      size={IconSize.LARGE}
+    />
+    <Icon
+      variant={IconVariant.CHAT}
+      color={Color.LIGHT}
+      size={IconSize.LARGE}
+    />
+    <Icon
+      variant={IconVariant.FILE}
+      color={Color.LIGHT}
+      size={IconSize.LARGE}
+    />
+    <Icon
+      variant={IconVariant.LOGIN}
+      color={Color.LIGHT}
+      size={IconSize.LARGE}
+    />
+    <Icon
+      variant={IconVariant.SEARCH}
+      color={Color.LIGHT}
+      size={IconSize.LARGE}
+    />
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/InputExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/InputExample.tsx
@@ -1,0 +1,15 @@
+import {
+  Input,
+  InputVariant,
+} from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+export const InputExample = () => (
+  <BookSection title='Input component'>
+    <Input
+      variant={InputVariant.LIGHT}
+      label="Light Input"
+      placeholder="Your email"
+    />
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/NavigationExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/NavigationExample.tsx
@@ -1,0 +1,10 @@
+import {
+  NavigationBar,
+} from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+export const NavigationExample = () => (
+  <BookSection title="Navigation component">
+    <NavigationBar />
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/RowExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/RowExample.tsx
@@ -1,20 +1,26 @@
-import {
-  IconVariant,
-  Row,
-} from '../../../shared/components';
-import { BookSection } from '../BookSection';
+import { IconVariant, Row } from '../../../shared/components';
+import { BookSection, BookSubsection } from '../BookSection';
 
 const randomAvatar = 'https://i.pravatar.cc/1000';
 const buttonAction = (): void => alert('This is an alert');
 
 export const RowExample = () => (
-  <BookSection title="Row component">
-    <Row
-      iconVariant={IconVariant.ARROW_FORWARD}
-      avatarProps={{ url: randomAvatar, status: 'playing' }}
-      onClick={buttonAction}
-      title="John Doe"
-      subtitle="level 3"
-    />
+  <BookSection title="Row component" displayVertical>
+    <BookSubsection title="All props">
+      <Row
+        iconVariant={IconVariant.ARROW_FORWARD}
+        avatarProps={{ url: randomAvatar, status: 'playing' }}
+        onClick={buttonAction}
+        title="John Doe"
+        subtitle="level 3"
+      />
+    </BookSubsection>
+    <BookSubsection title="Only title and icon configured">
+      <Row
+        iconVariant={IconVariant.EDIT}
+        onClick={buttonAction}
+        title="Edit profile"
+      />
+    </BookSubsection>
   </BookSection>
 );

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/RowExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/RowExample.tsx
@@ -1,0 +1,20 @@
+import {
+  IconVariant,
+  Row,
+} from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+const randomAvatar = 'https://i.pravatar.cc/1000';
+const buttonAction = (): void => alert('This is an alert');
+
+export const RowExample = () => (
+  <BookSection title="Row component">
+    <Row
+      iconVariant={IconVariant.ARROW_FORWARD}
+      avatarProps={{ url: randomAvatar, status: 'playing' }}
+      onClick={buttonAction}
+      title="John Doe"
+      subtitle="level 3"
+    />
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/RowsListExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/RowsListExample.tsx
@@ -1,0 +1,44 @@
+import { RowsList, RowItem, IconVariant } from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+const randomAvatar = 'https://i.pravatar.cc/1000';
+const randomAvatar2 = 'https://i.pravatar.cc/2000';
+const randomAvatar3 = 'https://i.pravatar.cc/3000';
+
+const buttonAction = (): void => alert('This is an alert');
+const buttonLink = (): void => {
+  window.location.href = 'https://google.com';
+};
+
+const rowsData: RowItem[] = [
+  {
+    iconVariant: IconVariant.ARROW_FORWARD,
+    avatarProps: { url: randomAvatar, status: 'online' },
+    onClick: buttonAction,
+    title: 'John Doe',
+    subtitle: 'level 3',
+    key: '75442486-0878-440c-9db1-a7006c25a39f',
+  },
+  {
+    iconVariant: IconVariant.ARROW_FORWARD,
+    avatarProps: { url: randomAvatar2, status: 'offline' },
+    onClick: buttonLink,
+    title: 'Jane Doe',
+    subtitle: 'level 99',
+    key: '99a46451-975e-4d08-a697-9fa9c15f47a6',
+  },
+  {
+    iconVariant: IconVariant.ARROW_FORWARD,
+    avatarProps: { url: randomAvatar3, status: 'playing' },
+    onClick: buttonAction,
+    title: 'Joe Shmoe',
+    subtitle: 'level 0',
+    key: '5c2013ba-45a0-45b9-b65e-750757df21a0',
+  },
+];
+
+export const RowsListExample = () => (
+  <BookSection title="Rows list component">
+    <RowsList rows={rowsData} />
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/StatusExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/StatusExample.tsx
@@ -4,7 +4,7 @@ import {
 import { BookSection } from '../BookSection';
 
 export const StatusExample = () => (
-  <BookSection title="Status component">
+  <BookSection title="Status component" displayVertical>
       <Status variant="online" />
       <Status variant="offline" />
       <Status variant="playing" />

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/StatusExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/StatusExample.tsx
@@ -1,0 +1,12 @@
+import {
+  Status,
+} from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+export const StatusExample = () => (
+  <BookSection title="Status component">
+      <Status variant="online" />
+      <Status variant="offline" />
+      <Status variant="playing" />
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/TextExample.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/TextExample.tsx
@@ -1,0 +1,33 @@
+import {
+  Text,
+  TextVariant,
+  TextWeight,
+  TextColor,
+} from '../../../shared/components';
+import { BookSection } from '../BookSection';
+
+export const TextExample = () => (
+  <BookSection title="Text component">
+    <Text
+      variant={TextVariant.TITLE}
+      color={TextColor.LIGHT}
+      weight={TextWeight.BOLD}
+    >
+      This is a title
+    </Text>
+    <Text
+      variant={TextVariant.SUBTITLE}
+      color={TextColor.LIGHT}
+      weight={TextWeight.BOLD}
+    >
+      This is a subtitle
+    </Text>
+    <Text
+      variant={TextVariant.HEADING}
+      color={TextColor.LIGHT}
+      weight={TextWeight.BOLD}
+    >
+      This is a heading
+    </Text>
+  </BookSection>
+);

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/index.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/index.tsx
@@ -1,0 +1,8 @@
+export { NavigationExample }from "./NavigationExample";
+export { TextExample }from "./TextExample";
+export { ButtonsExample }from "./ButtonsExample";
+export { StatusExample }from "./StatusExample";
+export { IconExample }from "./IconExample";
+export { AvatarExample }from "./AvatarExample";
+export { RowExample }from "./RowExample";
+export { InputExample }from "./InputExample";

--- a/webapp/src/pages/ComponentsBook/ComponentsExamples/index.tsx
+++ b/webapp/src/pages/ComponentsBook/ComponentsExamples/index.tsx
@@ -5,4 +5,6 @@ export { StatusExample }from "./StatusExample";
 export { IconExample }from "./IconExample";
 export { AvatarExample }from "./AvatarExample";
 export { RowExample }from "./RowExample";
+export { RowsListExample }from "./RowsListExample";
 export { InputExample }from "./InputExample";
+export { HeaderExample }from "./HeaderExample";

--- a/webapp/src/pages/index.ts
+++ b/webapp/src/pages/index.ts
@@ -2,3 +2,4 @@ export { default as Landing } from './Landing/Landing';
 export { default as Users } from './Users/Users';
 export { default as Play } from './Play/Play';
 export { default as Chat } from './Chat/Chat';
+export { default as ComponentsBook } from './ComponentsBook/ComponentsBook';

--- a/webapp/src/shared/components/Avatar/Avatar.css
+++ b/webapp/src/shared/components/Avatar/Avatar.css
@@ -10,6 +10,11 @@
     background: var(--gradient-game);
 }
 
+.avatar-small {
+    display: flex;
+}
+
+
 .avatar-large {
     position: relative;
     display: flex;

--- a/webapp/src/shared/components/Avatar/Avatar.tsx
+++ b/webapp/src/shared/components/Avatar/Avatar.tsx
@@ -16,9 +16,13 @@ type LargeAvatarProps = AvatarProps & {
 
 export function SmallAvatar({ url, status }: AvatarProps) {
   return (
-    <figure className={`avatar-small__image-wrapper  avatar-status--${status}`}>
-      <img src={url} alt={url} className="avatar-small__image" />
-    </figure>
+    <div className="avatar-small">
+      <figure
+        className={`avatar-small__image-wrapper  avatar-status--${status}`}
+      >
+        <img src={url} alt={url} className="avatar-small__image" />
+      </figure>
+    </div>
   );
 }
 
@@ -28,7 +32,6 @@ export function LargeAvatar({
   edit = false,
   caption,
 }: LargeAvatarProps) {
-
   const statusClass = status ? `avatar-status--${status}` : '';
 
   return (

--- a/webapp/src/shared/components/Input/Input.css
+++ b/webapp/src/shared/components/Input/Input.css
@@ -5,7 +5,7 @@
 }
 
 .input-container {
-  margin-top: 0.3rem;
+  margin-top: 1rem;
   display: flex;
   align-items: center;
   padding: 0.8rem 0.6rem;

--- a/webapp/src/shared/components/Input/Input.tsx
+++ b/webapp/src/shared/components/Input/Input.tsx
@@ -27,8 +27,10 @@ export default function Input({
   name,
 }: InputProps) {
   return (
-    <label className="input subheading-bold">
-      {label}
+    <div className="input">
+      <label className="subheading-bold">
+        {label}
+      </label>
       <div className={`input-container input-container-${variant}`}>
         {iconVariant && (
           <Icon
@@ -42,6 +44,6 @@ export default function Input({
           placeholder={placeholder}
         />
       </div>
-    </label>
+    </div>
   );
 }

--- a/webapp/src/shared/components/RowsList/RowsList.tsx
+++ b/webapp/src/shared/components/RowsList/RowsList.tsx
@@ -1,7 +1,7 @@
 import './RowsList.css';
 import Row, { RowProps } from '../Row/Row';
 
-type RowItem = RowProps & {
+export type RowItem = RowProps & {
   key: string;
 };
 
@@ -21,7 +21,6 @@ export default function RowsList({ rows }: RowsListProps) {
             </li>
           );
         })}
-      ;
     </ul>
   );
 }

--- a/webapp/src/shared/components/index.ts
+++ b/webapp/src/shared/components/index.ts
@@ -24,3 +24,4 @@ export { default as Header } from './Header/Header';
 export { default as Row } from './Row/Row';
 
 export { default as RowsList } from './RowsList/RowsList';
+export * from './RowsList/RowsList';

--- a/webapp/src/shared/urls.ts
+++ b/webapp/src/shared/urls.ts
@@ -1,3 +1,4 @@
 export const USERS_URL = '/users';
 export const PLAY_URL = '/play';
 export const CHAT_URL = '/chat';
+export const COMPONENTS_BOOK_URL = '/components-book';


### PR DESCRIPTION
- New componentBook section to test and see example of components (only available in dev) -> `npm run start` + navigate to http://localhost:3000/components-book
- Mini-fix of `SmallAvatar`: status wrapper width was expanding to any size of the component

closes #109 