### PR TITLE
Add a Docker volume to store transcendence-app data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,11 @@ services:
     depends_on:
       - "db"
       - "memcached"
+    build:
+      args:
+        - TRANSCENDENCE_APP_DATA=${TRANSCENDENCE_APP_DATA:-/var/lib/transcendence-app}
+    volumes:
+      - transcendence-app-data:${TRANSCENDENCE_APP_DATA:-/var/lib/transcendence-app}
 
   db:
     image: postgres:14.4-alpine3.16
@@ -30,6 +35,8 @@ services:
 
   memcached:
     image: memcached:1.6.15-alpine3.16
+    restart: always
 
 volumes:
   transcendence-db:
+  transcendence-app-data:

--- a/transcendence-app/.env.sample
+++ b/transcendence-app/.env.sample
@@ -7,6 +7,7 @@ FORTYTWO_APP_PROFILE_URL=https://api.intra.42.fr/v2/me
 NODE_ENV=development
 MEMCACHED_HOST=memcached
 MEMCACHED_PORT=11211
+TRANSCENDENCE_APP_DATA=/var/lib/transcendence-app
 
 # UUIDs format, generate with uuidgen
 SESSION_SECRET=80fbbf31-7083-419a-8fe1-23f1e10aae80

--- a/transcendence-app/Dockerfile
+++ b/transcendence-app/Dockerfile
@@ -1,24 +1,35 @@
 ARG NODE_VERSION=16.16.0
 ARG ALPINE_VERSION=3.16
+ARG TRANSCENDENCE_APP_DATA=/var/lib/transcendence-app
 
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS development
+ARG TRANSCENDENCE_APP_DATA
+ENV TRANSCENDENCE_APP_DATA=${TRANSCENDENCE_APP_DATA}
 ENV NODE_ENV=development
-RUN apk add --no-cache dumb-init
+RUN apk add --no-cache dumb-init \
+  && mkdir -p ${TRANSCENDENCE_APP_DATA} \
+  && chown -R node:node ${TRANSCENDENCE_APP_DATA}
 WORKDIR  /transcendence-app
 COPY ["package.json", "package-lock.json", "./"]
 RUN npm clean-install
 COPY . .
 RUN npm run build
+VOLUME ${TRANSCENDENCE_APP_DATA}
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["npm", "run", "start:dev"]
 
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS production
+ARG TRANSCENDENCE_APP_DATA
+ENV TRANSCENDENCE_APP_DATA=${TRANSCENDENCE_APP_DATA}
 ENV NODE_ENV=production
-RUN apk add --no-cache dumb-init
+RUN apk add --no-cache dumb-init \
+  && mkdir -p ${TRANSCENDENCE_APP_DATA} \
+  && chown -R node:node ${TRANSCENDENCE_APP_DATA}
 WORKDIR  /transcendence-app
 COPY ["package.json", "package-lock.json", "./"]
 RUN npm clean-install --production
 COPY --from=development --chown=node:node /transcendence-app/dist ./dist
 USER node
+VOLUME ${TRANSCENDENCE_APP_DATA}
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["node", "dist/main"]

--- a/transcendence-app/src/config/env.validation.ts
+++ b/transcendence-app/src/config/env.validation.ts
@@ -41,6 +41,10 @@ export class EnvironmentVariables {
   @IsPort()
   MEMCACHED_PORT!: string;
 
+  @IsString()
+  @IsNotEmpty()
+  TRANSCENDENCE_APP_DATA!: string;
+
   @IsUUID()
   SESSION_SECRET!: string;
 


### PR DESCRIPTION
Update transcendence-app Dockerfile
Add `TRANSCENDENCE_APP_DATA` environment variable
Set by default to the /var/lib/transcendence-app directory

Please add `TRANSCENDENCE_APP_DATA=/var/lib/transcendence-app` to the transcendence-app `.env` file

Subtask of #74