### PR TITLE
#114/Fix transcendence-app logout endpoint

### DIFF
--- a/transcendence-app/.gitignore
+++ b/transcendence-app/.gitignore
@@ -4,6 +4,8 @@
 
 # Environment files
 .env
+.env.development
+.env.production
 
 # Logs
 logs

--- a/transcendence-app/package-lock.json
+++ b/transcendence-app/package-lock.json
@@ -37,6 +37,7 @@
         "@types/express-session": "^1.17.5",
         "@types/jest": "28.1.4",
         "@types/node": "^18.0.3",
+        "@types/passport": "^1.0.9",
         "@types/passport-oauth2": "^1.4.11",
         "@types/pg": "^8.6.5",
         "@types/supertest": "^2.0.12",
@@ -2010,9 +2011,9 @@
       "dev": true
     },
     "node_modules/@types/passport": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.7.tgz",
-      "integrity": "sha512-JtswU8N3kxBYgo+n9of7C97YQBT+AYPP2aBfNGTzABqPAZnK/WOAaKfh3XesUYMZRrXFuoPc2Hv0/G/nQFveHw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.9.tgz",
+      "integrity": "sha512-9+ilzUhmZQR4JP49GdC2O4UdDE3POPLwpmaTC/iLkW7l0TZCXOo1zsTnnlXPq6rP1UsUZPfbAV4IUdiwiXyC7g==",
       "dev": true,
       "dependencies": {
         "@types/express": "*"
@@ -10293,9 +10294,9 @@
       "dev": true
     },
     "@types/passport": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.7.tgz",
-      "integrity": "sha512-JtswU8N3kxBYgo+n9of7C97YQBT+AYPP2aBfNGTzABqPAZnK/WOAaKfh3XesUYMZRrXFuoPc2Hv0/G/nQFveHw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.9.tgz",
+      "integrity": "sha512-9+ilzUhmZQR4JP49GdC2O4UdDE3POPLwpmaTC/iLkW7l0TZCXOo1zsTnnlXPq6rP1UsUZPfbAV4IUdiwiXyC7g==",
       "dev": true,
       "requires": {
         "@types/express": "*"

--- a/transcendence-app/package.json
+++ b/transcendence-app/package.json
@@ -50,6 +50,7 @@
     "@types/express-session": "^1.17.5",
     "@types/jest": "28.1.4",
     "@types/node": "^18.0.3",
+    "@types/passport": "^1.0.9",
     "@types/passport-oauth2": "^1.4.11",
     "@types/pg": "^8.6.5",
     "@types/supertest": "^2.0.12",

--- a/transcendence-app/src/auth/auth.controller.ts
+++ b/transcendence-app/src/auth/auth.controller.ts
@@ -36,10 +36,8 @@ export class AuthController {
   @ApiOkResponse({ description: 'Logout successfully' })
   @ApiNotFoundResponse({ description: 'Not Found' })
   logout(@GetRequest() req: Request) {
-    req.logout(function (err: Error) {
-      if (err) {
-        throw new NotFoundException(err.message);
-      }
+    req.logout((err: Error) => {
+        err && throw new NotFoundException(err.message);
     });
   }
 }

--- a/transcendence-app/src/auth/auth.controller.ts
+++ b/transcendence-app/src/auth/auth.controller.ts
@@ -37,7 +37,9 @@ export class AuthController {
   @ApiNotFoundResponse({ description: 'Not Found' })
   logout(@GetRequest() req: Request) {
     req.logout((err: Error) => {
-        err && throw new NotFoundException(err.message);
+      if (err) {
+        throw new NotFoundException(err.message);
+      }
     });
   }
 }

--- a/transcendence-app/src/auth/auth.controller.ts
+++ b/transcendence-app/src/auth/auth.controller.ts
@@ -2,16 +2,20 @@ import {
   Controller,
   Delete,
   Get,
+  NotFoundException,
   Request as GetRequest,
   UseGuards,
 } from '@nestjs/common';
 import {
-  ApiBadGatewayResponse,
+  ApiForbiddenResponse,
   ApiFoundResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
+  ApiServiceUnavailableResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { Request } from 'express';
+import { AuthenticatedGuard } from '../shared/guards/authenticated.guard';
 import { OAuth42Guard } from './oauth42.guard';
 
 @ApiTags('auth')
@@ -20,15 +24,22 @@ export class AuthController {
   @Get('login')
   @ApiOkResponse({ description: 'Login successfully' })
   @ApiFoundResponse({ description: 'Redirect to 42 OAuth server' })
-  @ApiBadGatewayResponse({ description: 'Bad Gateway' })
+  @ApiServiceUnavailableResponse({ description: 'Service unavailable' })
   @UseGuards(OAuth42Guard)
   oauth42Login() {
     // Guard implementation
   }
 
   @Delete('logout')
+  @UseGuards(AuthenticatedGuard)
+  @ApiForbiddenResponse({ description: 'Forbidden' })
   @ApiOkResponse({ description: 'Logout successfully' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
   logout(@GetRequest() req: Request) {
-    req.logout();
+    req.logout(function (err: Error) {
+      if (err) {
+        throw new NotFoundException(err.message);
+      }
+    });
   }
 }

--- a/transcendence-app/src/auth/oauth42.guard.ts
+++ b/transcendence-app/src/auth/oauth42.guard.ts
@@ -17,11 +17,9 @@ export class OAuth42Guard extends AuthGuard('oauth42') {
     return result;
   }
 
-  handleRequest(err: Error, user: any) {
+  handleRequest<User>(err: Error, user: User) {
     if (err || !user) {
-      if (err) {
-        this.logger.error(err.message);
-      }
+      err && this.logger.error(err.message);
       throw new ServiceUnavailableException();
     }
     return user;

--- a/transcendence-app/src/auth/oauth42.guard.ts
+++ b/transcendence-app/src/auth/oauth42.guard.ts
@@ -19,8 +19,10 @@ export class OAuth42Guard extends AuthGuard('oauth42') {
 
   handleRequest(err: Error, user: any) {
     if (err || !user) {
-      this.logger.error(err.message);
-      throw new ServiceUnavailableException(err.message);
+      if (err) {
+        this.logger.error(err.message);
+      }
+      throw new ServiceUnavailableException();
     }
     return user;
   }

--- a/transcendence-app/src/auth/oauth42.guard.ts
+++ b/transcendence-app/src/auth/oauth42.guard.ts
@@ -1,12 +1,15 @@
 import {
-  BadGatewayException,
   ExecutionContext,
   Injectable,
+  Logger,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class OAuth42Guard extends AuthGuard('oauth42') {
+  private readonly logger = new Logger(OAuth42Guard.name);
+
   async canActivate(context: ExecutionContext) {
     const result = (await super.canActivate(context)) as boolean;
     const request = context.switchToHttp().getRequest();
@@ -14,9 +17,10 @@ export class OAuth42Guard extends AuthGuard('oauth42') {
     return result;
   }
 
-  handleRequest(err: any, user: any) {
+  handleRequest(err: Error, user: any) {
     if (err || !user) {
-      throw new BadGatewayException();
+      this.logger.error(err.message);
+      throw new ServiceUnavailableException(err.message);
     }
     return user;
   }


### PR DESCRIPTION
The req.logout() method got an update. Now is async and takes a callback as an argument
Update Oauth42Guard -> Throw ServiceUnavailableException and log the error
Add a guard to the logout endpoint to return Forbidden if the user is not authenticated
Update @types/passport to the latest version

close #114