### PR TITLE
#72/Create controller and db adapter to update user info

### DIFF
--- a/transcendence-app/src/user/dto/update-user.dto.ts
+++ b/transcendence-app/src/user/dto/update-user.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsOptional } from 'class-validator';
+
+export class UpdateUserDto {
+  @IsEmail()
+  @IsOptional()
+  email?: string;
+}

--- a/transcendence-app/src/user/infrastructure/db/postgres/userPostgres.repository.ts
+++ b/transcendence-app/src/user/infrastructure/db/postgres/userPostgres.repository.ts
@@ -7,6 +7,7 @@ import { PostgresPool } from '../../../../shared/db/postgres/postgresConnection.
 import { UsersPaginationQueryDto } from '../../../dto/user.pagination.dto';
 import { BooleanString } from '../../../../shared/enums/boolean-string.enum';
 import { makeQuery } from '../../../../shared/db/postgres/utils';
+import { UpdateUserDto } from '../../../dto/update-user.dto';
 
 @Injectable()
 export class UserPostgresRepository
@@ -37,11 +38,11 @@ export class UserPostgresRepository
     return users && users.length ? users[0] : null;
   }
 
-  async updateByUsername(
-    username: string,
-    user: Partial<UserEntity>,
+  async updateById(
+    id: string,
+    updateUserDto: UpdateUserDto,
   ): Promise<UserEntity | null> {
-    const users = await this.updateByKey(userKeys.USERNAME, username, user);
+    const users = await this.updateByKey(userKeys.ID, id, updateUserDto);
     return users && users.length ? users[0] : null;
   }
 

--- a/transcendence-app/src/user/infrastructure/db/user.repository.ts
+++ b/transcendence-app/src/user/infrastructure/db/user.repository.ts
@@ -1,3 +1,4 @@
+import { UpdateUserDto } from '../../dto/update-user.dto';
 import { UsersPaginationQueryDto } from '../../dto/user.pagination.dto';
 import { User } from '../../user.domain';
 
@@ -6,9 +7,9 @@ export abstract class IUserRepository {
   abstract getByUsername(username: string): Promise<User | null>;
   abstract getByEmail(username: string): Promise<User | null>;
   abstract deleteByUsername(username: string): Promise<User | null>;
-  abstract updateByUsername(
+  abstract updateById(
     username: string,
-    user: Partial<User>,
+    updateUserDto: UpdateUserDto,
   ): Promise<User | null>;
   abstract add(user: User): Promise<User | null>;
   abstract getPaginatedUsers(

--- a/transcendence-app/src/user/user.controller.ts
+++ b/transcendence-app/src/user/user.controller.ts
@@ -1,10 +1,12 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
   NotFoundException,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
   Query,
   ServiceUnavailableException,
@@ -36,6 +38,7 @@ import {
   AVATAR_MAX_SIZE,
   AVATAR_MIMETYPE_WHITELIST,
 } from './constants';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 export const AvatarFileInterceptor = LocalFileInterceptor({
   fieldName: 'file',
@@ -79,6 +82,22 @@ export class UserController {
       throw new UnprocessableEntityException();
     }
     return user;
+  }
+
+  @Patch()
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  async updateCurrentUser(
+    @GetUser() user: User,
+    @Body() updateUserDto: UpdateUserDto,
+  ): Promise<User> {
+    const updatedUser = await this.userService.updateUser(
+      user.id,
+      updateUserDto,
+    );
+    if (!updatedUser) {
+      throw new BadRequestException();
+    }
+    return updatedUser;
   }
 
   @Get('me')

--- a/transcendence-app/src/user/user.service.ts
+++ b/transcendence-app/src/user/user.service.ts
@@ -8,6 +8,7 @@ import {
 import { BooleanString } from '../shared/enums/boolean-string.enum';
 import { IUserRepository } from './infrastructure/db/user.repository';
 import { User } from './user.domain';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Injectable()
 export class UserService {
@@ -39,5 +40,9 @@ export class UserService {
       createdAt: new Date(Date.now()),
       ...user,
     });
+  }
+
+  updateUser(userId: string, updateUserDto: UpdateUserDto) {
+    return this.userRepository.updateById(userId, updateUserDto);
   }
 }


### PR DESCRIPTION
This PR adds one endpoint:

PATCH [/api/v1/users](http://localhost:3000/api/#/users/UserController_updateCurrentUser) -> update the info of the currently authenticated user

![image](https://user-images.githubusercontent.com/54190400/183737495-b23a1e12-78a6-446d-b0dd-c4adcf1d3948.png)


close #72 
close #73 