### PR TITLE
#76/Search users by partial username

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "ft_transcendence",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/transcendence-app/src/user/dto/user.pagination.dto.ts
+++ b/transcendence-app/src/user/dto/user.pagination.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { BooleanString } from '../../shared/enums/boolean-string.enum';
 
 export const MAX_USER_ENTRIES_PER_PAGE = 20;
@@ -22,4 +22,8 @@ export class UsersPaginationQueryDto {
   @IsOptional()
   @IsEnum(BooleanString)
   sort?: BooleanString;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
 }

--- a/transcendence-app/src/user/infrastructure/db/postgres/userPostgres.repository.ts
+++ b/transcendence-app/src/user/infrastructure/db/postgres/userPostgres.repository.ts
@@ -54,16 +54,17 @@ export class UserPostgresRepository
   getPaginatedUsers(
     paginationDto: Required<UsersPaginationQueryDto>,
   ): Promise<UserEntity[] | null> {
-    const { limit, offset, sort } = paginationDto;
+    const { limit, offset, sort, search } = paginationDto;
     const orderBy =
       sort === BooleanString.True ? userKeys.USERNAME : userKeys.ID;
     return makeQuery<UserEntity>(this.pool, {
       text: `SELECT *
       FROM ${this.table}
+      WHERE ${userKeys.USERNAME} ILIKE $1
       ORDER BY ${orderBy}
-      LIMIT $1
-      OFFSET $2;`,
-      values: [limit, offset],
+      LIMIT $2
+      OFFSET $3;`,
+      values: [`%${search}%`, limit, offset],
     });
   }
 

--- a/transcendence-app/src/user/user.service.ts
+++ b/transcendence-app/src/user/user.service.ts
@@ -19,15 +19,17 @@ export class UserService {
     return this.userRepository.getById(id);
   }
 
-  retrieveUsers(queryDto: UsersPaginationQueryDto): Promise<User[] | null> {
-    const limit = queryDto.limit ?? MAX_USER_ENTRIES_PER_PAGE;
-    const offset = queryDto.offset ?? 0;
-    const sort = queryDto.sort ?? BooleanString.False;
-
+  retrieveUsers({
+    limit = MAX_USER_ENTRIES_PER_PAGE,
+    offset = 0,
+    sort = BooleanString.False,
+    search = '',
+  }: UsersPaginationQueryDto): Promise<User[] | null> {
     return this.userRepository.getPaginatedUsers({
       limit,
       offset,
       sort,
+      search,
     });
   }
 


### PR DESCRIPTION
This PR adds the `search` query param to the GET [`/api/v1/users`](http://localhost:3000/api#/users/UserController_getUsers) endpoint

close #76
close #77