### PR TITLE
#276/reorder make clean rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ gen:
 
 .PHONY: clean
 clean:
+	$(DOCKER_COMPOSE) down -v
 	rm -rf $(PROJECT_ROOT)/webapp/src/shared/generated || true
 	rm $(PROJECT_ROOT)/transcendence-app/swagger-spec.yaml || true
-	$(DOCKER_COMPOSE) down -v
 
 .PHONY: re
 re:


### PR DESCRIPTION
When running make clean, first we remove the generated code, and then stop the running deployment of our app. If a browser is actively running the app, it will complain that the generated files are missing, before it goes down. Removing the files AFTER stopping the deployment would make a more graceful shutdown.