### PR TITLE
#333/Reconnect the client socket after the user logout

### DIFF
--- a/webapp/src/shared/context/auth-context.tsx
+++ b/webapp/src/shared/context/auth-context.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { User } from '../generated';
 import { useData } from '../hooks/UseData';
 import { authApi, usersApi } from '../services/ApiService';
+import socket from '../socket';
 import { HOST_URL } from '../urls';
 
 export interface AuthContextType {
@@ -45,6 +46,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setIsLoading(isDataLoading);
     setAuthUser(data);
   }, [data, isDataLoading]);
+
+  useEffect(() => {
+    if (authUser) {
+      socket.connect();
+    }
+  }, [authUser]);
 
   const logout = useCallback(async () => {
     try {

--- a/webapp/src/shared/socket.ts
+++ b/webapp/src/shared/socket.ts
@@ -1,3 +1,3 @@
 import io from 'socket.io-client';
-const socket = io({ path: '/api/v1/socket.io' });
+const socket = io({ path: '/api/v1/socket.io', autoConnect: false });
 export default socket;


### PR DESCRIPTION
When a user logs in, we connect the socket, and when they log out, we [disconnect all the sockets with that `sessionId`](https://github.com/42AGV/ft_transcendence/blob/b389665dffe3a9383956da02893551cc46fa494f/transcendence-app/src/auth/auth.controller.ts#L67) .

fix #333