### PR TITLE
#337 add optional additional button to avatar page template

### DIFF
--- a/webapp/src/shared/components/templates/AvatarPageTemplate/AvatarPageTemplate.css
+++ b/webapp/src/shared/components/templates/AvatarPageTemplate/AvatarPageTemplate.css
@@ -43,8 +43,12 @@
   margin: 0;
 }
 
-.avatar-page-template .button {
-  justify-self: center;
+.avatar-page-template .avatar-page-buttons-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--row-gap);
+  grid-row: 3 / 4;
+  align-items: center;
 }
 
 @media all and (min-width: 768px) {
@@ -85,10 +89,13 @@
     flex-direction: column;
   }
 
-  .avatar-page-template .button {
-    margin-top: calc(var(--row-gap) * 3);
+  .avatar-page-template .avatar-page-buttons-wrapper {
+    display: flex;
+    flex-direction: row;
+    margin-top: calc(var(--row-gap) * 2.5);
     grid-column: 1 / var(--column-end);
     grid-row: 5 / 6;
+    justify-content: space-evenly;
   }
 }
 

--- a/webapp/src/shared/components/templates/AvatarPageTemplate/AvatarPageTemplate.tsx
+++ b/webapp/src/shared/components/templates/AvatarPageTemplate/AvatarPageTemplate.tsx
@@ -18,6 +18,7 @@ type AvatarPageTemplateProps = {
   avatarProps: LargeAvatarProps;
   children: JSX.Element;
   button?: ButtonProps;
+  secondaryButton?: ButtonProps;
 };
 
 export default function AvatarPageTemplate({
@@ -25,6 +26,7 @@ export default function AvatarPageTemplate({
   avatarProps,
   children,
   button,
+  secondaryButton,
   title,
   headerStatusVariant,
 }: AvatarPageTemplateProps) {
@@ -53,7 +55,10 @@ export default function AvatarPageTemplate({
         <LargeAvatar {...avatarProps} />
         <div className="generic-content-wrapper">{children}</div>
       </div>
-      {button && <Button {...button} />}
+      <div className="avatar-page-buttons-wrapper">
+        {button && <Button {...button} />}
+        {secondaryButton && <Button {...secondaryButton} />}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Between current main and commit c3bd9372da6b661cd5121fb526f3f098f91213d6 , some commits were lost (namely at least this 1208122abc909b4810cbdade0174ff3f0122f28e and this a1216f46ce0aa0cd33c95ceae1e228c2f219461a ).
This makes it so that the pages from the ancestry of the `edit user page`, have a slightly different styling than the pages made from the ancestry of the user page.
This PR is the first of three, where it provides the necessary functionality to the avatar page template to fit the edit chat page as well, as a series of fitting edit chat page and edit user page into the avatar page template.