### PR TITLE
#352/Implement user blocking in the chatroom messages

### DIFF
--- a/transcendence-app/src/auth/auth.module.ts
+++ b/transcendence-app/src/auth/auth.module.ts
@@ -12,7 +12,7 @@ import { HTTP_TIMEOUT_MILLISECONDS } from '../shared/constants';
 import { LocalStrategy } from './local.strategy';
 import { OAuth42Strategy } from './oauth42.strategy';
 import { SessionSerializer } from './session.serializer';
-import { ChatModule } from '../chat/chat.module';
+import { SocketModule } from '../socket/socket.module';
 
 @Module({
   imports: [
@@ -21,7 +21,7 @@ import { ChatModule } from '../chat/chat.module';
     }),
     DbModule,
     UserModule,
-    ChatModule,
+    SocketModule,
     PassportModule.register({ session: true }),
     LocalFileModule,
     AuthProviderModule,

--- a/transcendence-app/src/socket/socket.service.ts
+++ b/transcendence-app/src/socket/socket.service.ts
@@ -4,4 +4,16 @@ import { Server } from 'socket.io';
 @Injectable()
 export class SocketService {
   public socket: Server | null = null;
+
+  addBlock(blockerId: string, blockedId: string) {
+    if (this.socket) {
+      this.socket.to(blockerId).emit('block', blockedId);
+    }
+  }
+
+  deleteBlock(blockerId: string, blockedId: string) {
+    if (this.socket) {
+      this.socket.to(blockerId).emit('unblock', blockedId);
+    }
+  }
 }

--- a/transcendence-app/src/user/infrastructure/db/block.repository.ts
+++ b/transcendence-app/src/user/infrastructure/db/block.repository.ts
@@ -1,4 +1,5 @@
 import { Block } from './block.entity';
+import { User } from './user.entity';
 
 export abstract class IBlockRepository {
   abstract addBlock(block: Block): Promise<Block | null>;
@@ -10,4 +11,5 @@ export abstract class IBlockRepository {
     blockerId: string,
     blockedId: string,
   ): Promise<Block | null>;
+  abstract getBlocks(blockerId: string): Promise<User[] | null>;
 }

--- a/transcendence-app/src/user/infrastructure/db/postgres/block.postgres.repository.ts
+++ b/transcendence-app/src/user/infrastructure/db/postgres/block.postgres.repository.ts
@@ -5,6 +5,7 @@ import { PostgresPool } from '../../../../shared/db/postgres/postgresConnection.
 import { makeQuery } from '../../../../shared/db/postgres/utils';
 import { Block, BlockKeys } from '../block.entity';
 import { IBlockRepository } from '../block.repository';
+import { User, UserData, userKeys } from '../user.entity';
 
 @Injectable()
 export class BlockPostgresRepository
@@ -41,5 +42,16 @@ export class BlockPostgresRepository
       values: [blockerId, blockedId],
     });
     return blockData && blockData.length ? new this.ctor(blockData[0]) : null;
+  }
+
+  async getBlocks(blockerId: string): Promise<User[] | null> {
+    const usersData = await makeQuery<UserData>(this.pool, {
+      text: `SELECT u.*
+      FROM ${this.table} b
+      JOIN ${table.USERS} u ON (b.${BlockKeys.BLOCKED_ID} = u.${userKeys.ID})
+      WHERE b.${BlockKeys.BLOCKER_ID} = $1`,
+      values: [blockerId],
+    });
+    return usersData ? usersData.map((userData) => new User(userData)) : null;
   }
 }

--- a/transcendence-app/src/user/infrastructure/db/user.entity.ts
+++ b/transcendence-app/src/user/infrastructure/db/user.entity.ts
@@ -14,7 +14,7 @@ export enum userKeys {
   AVATAR_Y = '"avatarY"',
 }
 
-interface UserData {
+export interface UserData {
   id: string;
   username: string;
   email: string;

--- a/transcendence-app/src/user/user.controller.ts
+++ b/transcendence-app/src/user/user.controller.ts
@@ -198,19 +198,30 @@ export class UserController {
     return avatar;
   }
 
+  @Get('block/list')
+  @ApiOkResponse({
+    description: 'List users blocked by the authenticated user',
+    type: [User],
+  })
+  @ApiServiceUnavailableResponse({ description: 'Service Unavailable' })
+  async getBlocks(@GetUser() user: User): Promise<User[]> {
+    const blockedUsers = await this.userService.getBlocks(user.id);
+    if (!blockedUsers) {
+      throw new ServiceUnavailableException();
+    }
+    return blockedUsers;
+  }
+
   @Post('block/:userId')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiNoContentResponse({ description: 'Block a user' })
   @ApiBadRequestResponse({ description: 'Bad Request' })
   @ApiUnprocessableEntityResponse({ description: 'Unprocessable Entity' })
-  async blockUser(
+  blockUser(
     @GetUser() user: User,
     @Param('userId', ParseUUIDPipe) blockedUserId: string,
   ): Promise<void> {
-    const block = await this.userService.addBlock(user.id, blockedUserId);
-    if (!block) {
-      throw new UnprocessableEntityException();
-    }
+    return this.userService.addBlock(user.id, blockedUserId);
   }
 
   @Delete('block/:userId')
@@ -220,13 +231,10 @@ export class UserController {
   })
   @ApiBadRequestResponse({ description: 'Bad Request' })
   @ApiNotFoundResponse({ description: 'Not Found' })
-  async unblockUser(
+  unblockUser(
     @GetUser() user: User,
     @Param('userId', ParseUUIDPipe) blockedUserId: string,
   ): Promise<void> {
-    const block = await this.userService.deleteBlock(user.id, blockedUserId);
-    if (!block) {
-      throw new NotFoundException();
-    }
+    return this.userService.deleteBlock(user.id, blockedUserId);
   }
 }

--- a/transcendence-app/src/user/user.module.ts
+++ b/transcendence-app/src/user/user.module.ts
@@ -3,9 +3,10 @@ import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { DbModule } from '../shared/db/db.module';
 import { LocalFileModule } from '../shared/local-file/local-file.module';
+import { SocketModule } from '../socket/socket.module';
 
 @Module({
-  imports: [DbModule, LocalFileModule],
+  imports: [DbModule, LocalFileModule, SocketModule],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "downlevelIteration": true,
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
This PR adds a new endpoint to get a list of the users blocked by the authenticated user.

When they open a chatroom page, they fetch a list of blocked users and filter the messages.

When the authenticated user blocks or unblocks a user, the server sends a block or unblock event to which the client listens and updates the list of blocked users.

This way, the messages are filtered even if a user blocks another user from another tab, browser, or device.

To do:

- [ ] We could create a context and custom hook for the block list and use it in more places

close #352