### PR TITLE
#365/Fix/Add-a-Github-Action-to-Deploy-to-DigitalOcean-when-we-merge-to-the-main-branch

### DIFF
--- a/.github/workflows/deploy_do.yml
+++ b/.github/workflows/deploy_do.yml
@@ -11,11 +11,10 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out Github repository
-        uses: actions/checkout@v2
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Deploy the application
-        run: doctl compute ssh --ssh-command "cd /srv/ft_transcendence && git pull && make prod-re" transcendence
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DIGITALOCEAN_SSH_HOST }}
+          username: ${{ secrets.DIGITALOCEAN_SSH_USERNAME }}
+          key: ${{ secrets.DIGITALOCEAN_SSH_KEY }}
+          script: cd /srv/ft_transcendence && git pull && make prod-re


### PR DESCRIPTION
Remove `doctl` and execute remote ssh commands using ssh key

Fix #365