### PR TITLE
#382 / improve mobile sizing

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -16,7 +16,7 @@
   --heading-font-size: 1.5rem;
   --subheading-font-size: 1.15rem;
   --paragraph-font-size: 1rem;
-  --caption-font-size: 0.875rem;
+  --caption-font-size: 0.75rem;
 
   --gradient-game: linear-gradient(
     269.73deg,
@@ -27,7 +27,7 @@
 
   --primary-font: 'DM Sans', sans-serif;
 
-  font-size: 16px;
+  font-size: 14px;
   --column-number: 4;
   --column-end: calc(var(--column-number) + 1);
   --padding-sides: 1.25rem;

--- a/webapp/src/shared/components/Button/Button.css
+++ b/webapp/src/shared/components/Button/Button.css
@@ -23,6 +23,15 @@
   border-radius: 50%;
 }
 
+.button-chip {
+  border-radius: 1rem;
+  height: 1.5rem;
+  min-width: 8rem;
+  max-width: 12rem;
+  padding: 1rem;
+  padding-left: 2rem;
+}
+
 .button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -49,4 +58,10 @@
   display: flex;
   position: absolute;
   left: 1rem;
+}
+
+.button-chip .button-icon {
+  display: flex;
+  position: absolute;
+  left: 0.675rem;
 }

--- a/webapp/src/shared/components/Button/Button.tsx
+++ b/webapp/src/shared/components/Button/Button.tsx
@@ -11,6 +11,7 @@ export enum ButtonVariant {
 export enum ButtonSize {
   SMALL = 'small',
   LARGE = 'large',
+  CHIP = 'chip',
 }
 
 type CommonButtonProps = {
@@ -26,11 +27,15 @@ type LargeButtonProps = CommonButtonProps & {
   children: string;
 };
 
+type ChipButtonProps = CommonButtonProps & {
+  children: string;
+};
+
 type SmallButtonProps = CommonButtonProps & {
   children?: never;
 };
 
-export type ButtonProps = SmallButtonProps | LargeButtonProps;
+export type ButtonProps = SmallButtonProps | LargeButtonProps | ChipButtonProps;
 
 export default function Button({
   variant,
@@ -41,23 +46,42 @@ export default function Button({
   children,
   buttonSize = ButtonSize.LARGE,
 }: ButtonProps) {
+  const getButtonSizeClass = () => {
+    if (children) {
+      switch (buttonSize) {
+        case ButtonSize.SMALL:
+          return 'button-small';
+        case ButtonSize.CHIP:
+          return 'button-chip caption-regular';
+        default:
+          return 'button-large';
+      }
+    }
+    return 'button-small';
+  };
+
   return (
     <button
-      className={`${
-        children && buttonSize === ButtonSize.LARGE
-          ? 'button-large'
-          : 'button-small'
-      } button subheading-bold button-${variant}`}
+      className={`${getButtonSizeClass()} button subheading-bold button-${variant}`}
       disabled={disabled}
       onClick={onClick}
       form={form}
     >
       {iconVariant && (
         <div className="button-icon">
-          {<Icon variant={iconVariant} size={IconSize.SMALL} />}
+          {
+            <Icon
+              variant={iconVariant}
+              size={
+                buttonSize === ButtonSize.CHIP
+                  ? IconSize.EXTRA_SMALL
+                  : IconSize.SMALL
+              }
+            />
+          }
         </div>
       )}
-      {children && buttonSize === ButtonSize.LARGE && children}
+      {children && buttonSize !== ButtonSize.SMALL && children}
     </button>
   );
 }

--- a/webapp/src/shared/components/Button/ReactiveButton.css
+++ b/webapp/src/shared/components/Button/ReactiveButton.css
@@ -1,5 +1,6 @@
 .reactive-button {
-  display: contents;
+  display: flex;
+  align-items: center;
 }
 
 @media all and (max-width: 768px) {
@@ -8,7 +9,7 @@
   }
 }
 @media all and (min-width: 769px) {
-  .reactive-button .button-small {
+  .reactive-button .button-chip {
     display: none;
   }
 }

--- a/webapp/src/shared/components/Button/ReactiveButton.tsx
+++ b/webapp/src/shared/components/Button/ReactiveButton.tsx
@@ -1,11 +1,11 @@
-import './ReactiveButton.css';
-import React from 'react';
 import Button, { ButtonProps, ButtonSize } from './Button';
+
+import './ReactiveButton.css';
 
 export default function ReactiveButton(props: ButtonProps) {
   return (
     <div className="reactive-button">
-      <Button {...{ ...props, buttonSize: ButtonSize.SMALL }} />
+      <Button {...{ ...props, buttonSize: ButtonSize.CHIP }} />
       <Button {...{ ...props, buttonSize: ButtonSize.LARGE }} />
     </div>
   );

--- a/webapp/src/shared/components/Icon/Icon.tsx
+++ b/webapp/src/shared/components/Icon/Icon.tsx
@@ -54,6 +54,7 @@ const Icons: { [key in IconVariant]: SVGComponent } = {
 };
 
 export enum IconSize {
+  EXTRA_SMALL = '0.875rem',
   SMALL = '1.25rem',
   LARGE = '1.5rem',
 }

--- a/webapp/src/shared/components/NavigationBar/NavigationBar.css
+++ b/webapp/src/shared/components/NavigationBar/NavigationBar.css
@@ -1,5 +1,5 @@
 .navigation-bar {
-  width: 100%;
+  margin: 0 1rem;
 }
 
 .navigation-bar ul {

--- a/webapp/src/shared/components/Row/Row.css
+++ b/webapp/src/shared/components/Row/Row.css
@@ -5,7 +5,7 @@
   grid-template-rows: 1fr;
   width: 100%;
   min-width: fit-content;
-  padding: 1rem 1.75rem;
+  padding: 0.5rem 1.75rem;
   border-radius: 0.5rem;
   column-gap: 1.25rem;
   color: var(--color-light);

--- a/webapp/src/shared/components/RowsList/RowsList.css
+++ b/webapp/src/shared/components/RowsList/RowsList.css
@@ -6,5 +6,5 @@
 }
 
 .rows-list-item:not(:last-child) {
-  margin-bottom: 1.75rem;
+  margin-bottom: 0.75rem;
 }

--- a/webapp/src/shared/components/templates/MainTabPageTemplate/MainTabPageTemplate.css
+++ b/webapp/src/shared/components/templates/MainTabPageTemplate/MainTabPageTemplate.css
@@ -7,7 +7,7 @@
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto auto 1fr auto;
-  gap: 2rem var(--column-gap);
+  gap: 0.5rem var(--column-gap);
 }
 
 .main-tab-template-loading {

--- a/webapp/src/shared/components/templates/RowsListTemplate/RowsListTemplate.tsx
+++ b/webapp/src/shared/components/templates/RowsListTemplate/RowsListTemplate.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import SearchForm from '../../Input/SearchForm';
 import RowsList, { RowItem } from '../../RowsList/RowsList';
 import Loading from '../../Loading/Loading';


### PR DESCRIPTION
Closes #382

Finally, a lot of space has been gained by reducing margins and sizes so no need to move search bar and make the buttons floating.

I've also added text to the ReactiveButton mobile view so it's clearer what the action is about, tested with my smartphone is pretty readable 👌 