### PR TITLE
#404/fix instantiation of the subject in the global guard

### DIFF
--- a/transcendence-app/src/auth/auth.controller.ts
+++ b/transcendence-app/src/auth/auth.controller.ts
@@ -40,6 +40,7 @@ import { CheckPolicies } from '../authorization/decorators/policies.decorator';
 import { Action } from '../shared/enums/action.enum';
 import { SetSubjects } from '../authorization/decorators/set-subjects.decorator';
 import { UserToRoleDto } from '../authorization/dto/user-to-role.dto';
+import { UserToRole } from '../authorization/infrastructure/db/user-to-role.entity';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -105,7 +106,7 @@ export class AuthController {
   }
 
   @Post('authorization/role')
-  @SetSubjects(UserToRoleDto)
+  @SetSubjects(UserToRole)
   @UseGuards(GlobalPoliciesGuard)
   @CheckPolicies((ability, userToRole) =>
     ability.can(Action.Create, userToRole),
@@ -119,7 +120,7 @@ export class AuthController {
   }
 
   @Delete('authorization/role')
-  @SetSubjects(UserToRoleDto)
+  @SetSubjects(UserToRole)
   @UseGuards(GlobalPoliciesGuard)
   @CheckPolicies((ability, userToRole) =>
     ability.can(Action.Delete, userToRole),

--- a/transcendence-app/src/authorization/casl-ability.factory.ts
+++ b/transcendence-app/src/authorization/casl-ability.factory.ts
@@ -13,13 +13,13 @@ import { ChatroomMember } from '../chat/chatroom/chatroom-member/infrastructure/
 import { UpdateChatroomMemberDto } from '../chat/chatroom/chatroom-member/dto/update-chatroom-member.dto';
 import { Chatroom } from '../chat/chatroom/infrastructure/db/chatroom.entity';
 import { Role } from '../shared/enums/role.enum';
-import { UserToRoleDto } from './dto/user-to-role.dto';
+import { UserToRole } from './infrastructure/db/user-to-role.entity';
 
 export type SubjectCtors =
   | typeof ChatroomMember
   | typeof UpdateChatroomMemberDto
   | typeof Chatroom
-  | typeof UserToRoleDto;
+  | typeof UserToRole;
 
 export type Subject = InferSubjects<SubjectCtors>;
 
@@ -30,7 +30,7 @@ export class CaslAbilityFactory {
     { can, cannot, build }: AbilityBuilder<AnyMongoAbility>,
     globalUserAuthCtx: UserWithAuthorization,
   ) {
-    cannot(Action.Manage, UserToRoleDto);
+    cannot(Action.Manage, UserToRole);
     if (globalUserAuthCtx.g_banned) {
       cannot(Action.Manage, 'all');
     } else if (globalUserAuthCtx.g_admin && !globalUserAuthCtx.g_owner) {
@@ -39,7 +39,7 @@ export class CaslAbilityFactory {
     if (globalUserAuthCtx.g_owner) {
       can(Action.Manage, 'all');
     }
-    cannot(Action.Manage, UserToRoleDto, {
+    cannot(Action.Manage, UserToRole, {
       role: Role.owner,
     });
     return build({


### PR DESCRIPTION
There is a bug, that this PR attempts to fix, where the global policies guard is not actually instantiating the usertoroleDto (Because the userToRoleDto doesn't have a constructor) class to pass it to the `ability.can(...,usertoroledto)`. This fixes it by using the user-to-role.entity instead for the casl logic, separating it from the data transfer (that still uses the dto).