### PR TITLE
Fix library package compilation in development mode

### DIFF
--- a/packages/pong-engine/package.json
+++ b/packages/pong-engine/package.json
@@ -8,7 +8,7 @@
     "style": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "lint": "eslint \"{src,apps,libs,test}/**/*.{ts,tsx}\" --fix",
-    "build": "rm -rf ./lib && tsc"
+    "build": "tsc"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
closes #477 

When the project is up and running in development mode, we are facing some issues with library builds:

- If rebuilding the lib, the webapp and transcendence app warn about not being able to find the library causing we have to re launch the app with `make re` or `make`
- The first time we launch the app with a simple `make` we get the same error.

This is happening because we are deleting the generated ts `lib` every time we rebuild it. Since each of webapp and transcendence-app link to the build package, due to it being deleted, they display that error.