### PR TITLE
#588 / game configuration

### DIFF
--- a/packages/pong-engine/src/constants.ts
+++ b/packages/pong-engine/src/constants.ts
@@ -5,6 +5,7 @@ export const CANVAS_HEIGHT = 500;
 export const BRICK_WIDTH = 40;
 export const BRICK_HEIGHT = 5;
 export const PADDLE_WIDTH = 80;
+export const SHORT_PADDLE_WIDTH = 40;
 export const PADDLE_HEIGHT = 8;
 export const PADDLE_SLIDE_SPEED = 400;
 export const BALL_RADIUS = 8;
@@ -14,3 +15,7 @@ export const MAX_PADDLE_OPPONENT_BOUNCE_ANGLE =
   MIN_PADDLE_BOUNCE_ANGLE + Math.PI;
 export const MIN_PADDLE_OPPONENT_BOUNCE_ANGLE =
   MAX_PADDLE_BOUNCE_ANGLE + Math.PI;
+export const MISTERY_ZONE_HEIGH = 100;
+
+export const getPaddleWidth = (short = false) =>
+  short ? SHORT_PADDLE_WIDTH : PADDLE_WIDTH;

--- a/packages/pong-engine/src/game.ts
+++ b/packages/pong-engine/src/game.ts
@@ -70,10 +70,10 @@ export const paddleOpponentDrag = (
   });
 };
 
-export const newGame = (): GameState => ({
+export const newGame = (paddleShort = false): GameState => ({
   ball: initialBallState(),
-  paddle: initialPaddleState(),
-  paddleOpponent: initialPaddleOpponentState(),
+  paddle: initialPaddleState(paddleShort),
+  paddleOpponent: initialPaddleOpponentState(paddleShort),
   score: 0,
   scoreOpponent: 0,
 });

--- a/packages/pong-engine/src/models.ts
+++ b/packages/pong-engine/src/models.ts
@@ -25,6 +25,7 @@ export type GamePaddle = GameElement & {
   slide: number;
   width: number;
   height: number;
+  short?: boolean;
 };
 
 export type GameBall = GameElement & {
@@ -48,11 +49,14 @@ export type GameState = {
 
 export type PlayState = 'playing' | 'paused';
 
+export type GameMode = 'classic' | 'shortPaddle' | 'misteryZone';
+
 export type GameInfoClient = {
   gameState: GameState;
   playState: PlayState;
   playerOneId: string;
   playerTwoId: string;
+  gameMode: GameMode | null;
 };
 
 export type GameInfoServer = GameInfoClient & {

--- a/packages/pong-engine/src/models.ts
+++ b/packages/pong-engine/src/models.ts
@@ -49,7 +49,7 @@ export type GameState = {
 
 export type PlayState = 'playing' | 'paused';
 
-export type GameMode = 'classic' | 'shortPaddle' | 'misteryZone';
+export type GameMode = 'classic' | 'shortPaddle' | 'mysteryZone';
 
 export type GameInfoClient = {
   gameState: GameState;

--- a/packages/pong-engine/src/physics.ts
+++ b/packages/pong-engine/src/physics.ts
@@ -5,10 +5,10 @@ import {
   MIN_PADDLE_BOUNCE_ANGLE,
   MAX_PADDLE_OPPONENT_BOUNCE_ANGLE,
   MIN_PADDLE_OPPONENT_BOUNCE_ANGLE,
-  PADDLE_WIDTH,
   PADDLE_SLIDE_SPEED,
   BALL_RADIUS,
   PADDLE_HEIGHT,
+  getPaddleWidth,
 } from './constants';
 import { GameBall, GamePaddle, Coord } from './models';
 
@@ -59,7 +59,7 @@ const bounceArkanoid = (
   const paddleBallDistance = ball.x - paddle.x;
   const bounceAngle =
     MAX_PADDLE_BOUNCE_ANGLE -
-    (paddleBallDistance / PADDLE_WIDTH) *
+    (paddleBallDistance / getPaddleWidth(paddle.short)) *
       (MAX_PADDLE_BOUNCE_ANGLE - MIN_PADDLE_BOUNCE_ANGLE);
   return getArkanoidBounce(ball, bounceAngle, deltaTime);
 };
@@ -72,7 +72,7 @@ const bounceArkanoidOpponent = (
   const paddleBallDistance = ball.x - paddle.x;
   const bounceAngle =
     MAX_PADDLE_OPPONENT_BOUNCE_ANGLE -
-    (paddleBallDistance / PADDLE_WIDTH) *
+    (paddleBallDistance / getPaddleWidth(paddle.short)) *
       (MAX_PADDLE_OPPONENT_BOUNCE_ANGLE - MIN_PADDLE_OPPONENT_BOUNCE_ANGLE);
   return getArkanoidBounce(ball, bounceAngle, deltaTime);
 };
@@ -157,7 +157,7 @@ export const getPaddlePos = (
 ): GamePaddle => {
   if (
     (paddle.x > 0 && paddle.slide < 0) ||
-    (paddle.x < CANVAS_WIDTH - PADDLE_WIDTH && paddle.slide > 0)
+    (paddle.x < CANVAS_WIDTH - getPaddleWidth(paddle.short) && paddle.slide > 0)
   ) {
     return {
       ...paddle,
@@ -176,8 +176,8 @@ export const dragPaddle = (
 
   if (deltaX < 0) {
     deltaX = 0;
-  } else if (deltaX > CANVAS_WIDTH - PADDLE_WIDTH) {
-    deltaX = CANVAS_WIDTH - PADDLE_WIDTH;
+  } else if (deltaX > CANVAS_WIDTH - getPaddleWidth(paddle.short)) {
+    deltaX = CANVAS_WIDTH - getPaddleWidth(paddle.short);
   }
 
   return {

--- a/packages/pong-engine/src/physics.ts
+++ b/packages/pong-engine/src/physics.ts
@@ -155,13 +155,15 @@ export const getPaddlePos = (
   paddle: GamePaddle,
   deltaTime: number,
 ): GamePaddle => {
+  const newPaddleX = paddle.x + paddle.slide * deltaTime;
+
   if (
-    (paddle.x > 0 && paddle.slide < 0) ||
-    (paddle.x < CANVAS_WIDTH - getPaddleWidth(paddle.short) && paddle.slide > 0)
+    newPaddleX > 0 &&
+    newPaddleX < CANVAS_WIDTH - getPaddleWidth(paddle.short)
   ) {
     return {
       ...paddle,
-      x: paddle.x + paddle.slide * deltaTime,
+      x: newPaddleX,
     };
   }
   return paddle;

--- a/packages/pong-engine/src/state.ts
+++ b/packages/pong-engine/src/state.ts
@@ -19,9 +19,9 @@ import {
 import {
   CANVAS_WIDTH,
   CANVAS_HEIGHT,
-  PADDLE_WIDTH,
   PADDLE_HEIGHT,
   BALL_RADIUS,
+  getPaddleWidth,
 } from './constants';
 
 type EmptyPayload = object;
@@ -60,22 +60,27 @@ export const initialBallState = (): GameBall => {
   };
 };
 
-export const initialPaddleState = (): GamePaddle => ({
-  x: CANVAS_WIDTH / 2 - PADDLE_WIDTH / 2,
+export const calcInitialPaddleX = (short = false): number =>
+  CANVAS_WIDTH / 2 - getPaddleWidth(short) / 2;
+
+export const initialPaddleState = (short = false): GamePaddle => ({
+  x: calcInitialPaddleX(short),
   y: CANVAS_HEIGHT - 2 * PADDLE_HEIGHT,
   slide: 0,
-  width: PADDLE_WIDTH,
+  width: getPaddleWidth(short),
   height: PADDLE_HEIGHT,
   color: '#FFF',
+  short,
 });
 
-export const initialPaddleOpponentState = (): GamePaddle => ({
-  x: CANVAS_WIDTH / 2 - PADDLE_WIDTH / 2,
+export const initialPaddleOpponentState = (short = false): GamePaddle => ({
+  x: CANVAS_WIDTH / 2 - getPaddleWidth(short) / 2,
   y: PADDLE_HEIGHT,
   slide: 0,
-  width: PADDLE_WIDTH,
+  width: getPaddleWidth(short),
   height: PADDLE_HEIGHT,
   color: '#FFF',
+  short,
 });
 
 export const reducer = (

--- a/transcendence-app/src/game/dto/game-config.dto.ts
+++ b/transcendence-app/src/game/dto/game-config.dto.ts
@@ -1,0 +1,10 @@
+import { IsUUID } from 'class-validator';
+import { IsGameMode } from '../validators';
+
+export class GameConfigDto {
+  @IsGameMode()
+  gameMode!: string;
+
+  @IsUUID()
+  gameRoomId!: string;
+}

--- a/transcendence-app/src/game/enums/game-mode.enum.ts
+++ b/transcendence-app/src/game/enums/game-mode.enum.ts
@@ -1,4 +1,7 @@
 export enum GameMode {
   training = 'training',
   classic = 'classic',
+  shortPaddle = 'shortPaddle',
+  misteryZone = 'misteryZone',
+  unknown = 'unknown',
 }

--- a/transcendence-app/src/game/enums/game-mode.enum.ts
+++ b/transcendence-app/src/game/enums/game-mode.enum.ts
@@ -2,6 +2,6 @@ export enum GameMode {
   training = 'training',
   classic = 'classic',
   shortPaddle = 'shortPaddle',
-  misteryZone = 'misteryZone',
+  mysteryZone = 'mysteryZone',
   unknown = 'unknown',
 }

--- a/transcendence-app/src/game/game.gateway.ts
+++ b/transcendence-app/src/game/game.gateway.ts
@@ -15,6 +15,7 @@ import {
 import { Socket, Server } from 'socket.io';
 import { BadRequestTransformationFilter } from '../shared/filters/bad-request-transformation.filter';
 import { TwoFactorAuthenticatedGuard } from '../shared/guards/two-factor-authenticated.guard';
+import { GameConfigDto } from './dto/game-config.dto';
 import { GameInputDto } from './dto/game-input.dto';
 import { GameService } from './game.service';
 
@@ -68,5 +69,13 @@ export class GameGateway {
   @SubscribeMessage('getPlayingUsers')
   handleGetPlayingUsers(@ConnectedSocket() client: Socket) {
     client.emit('playingUsers', [...this.gameService.getPlayingUsers()]);
+  }
+
+  @SubscribeMessage('gameConfigSubmit')
+  handleGameConfigSubmit(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() gameConfigDto: GameConfigDto,
+  ) {
+    this.gameService.handleGameConfig(client, gameConfigDto);
   }
 }

--- a/transcendence-app/src/game/game.service.ts
+++ b/transcendence-app/src/game/game.service.ts
@@ -36,7 +36,7 @@ type UserId = string;
 type ClientId = string;
 type PlayerId = string;
 
-const FPS = 30;
+const FPS = 60;
 const DELTA_TIME = 1 / FPS;
 const MAX_PAUSED_TIME_MS = 30 * 1000; // 30 seconds
 const MAX_SCORE = 10;

--- a/transcendence-app/src/game/game.service.ts
+++ b/transcendence-app/src/game/game.service.ts
@@ -102,8 +102,8 @@ export class GameService {
         return GameModeEnum.classic;
       case 'shortPaddle':
         return GameModeEnum.shortPaddle;
-      case 'misteryZone':
-        return GameModeEnum.misteryZone;
+      case 'mysteryZone':
+        return GameModeEnum.mysteryZone;
       default:
         return GameModeEnum.unknown;
     }

--- a/transcendence-app/src/game/validators/index.ts
+++ b/transcendence-app/src/game/validators/index.ts
@@ -8,7 +8,7 @@ const GAME_COMMANDS = [
   'paddleDrag',
 ];
 
-const GAME_MODES = ['classic', 'shortPaddle', 'misteryZone'];
+const GAME_MODES = ['classic', 'shortPaddle', 'mysteryZone'];
 
 // https://stackoverflow.com/questions/51528780/typescript-check-typeof-against-custom-type
 type GameCommandType = (typeof GAME_COMMANDS)[number];
@@ -44,7 +44,7 @@ export function IsGameMode() {
       target: object.constructor,
       propertyName: propertyName,
       options: {
-        message: 'The value passed as command is not a valid game command',
+        message: 'The value passed as command is not a valid game mode',
       },
       validator: {
         validate(value: string) {

--- a/transcendence-app/src/game/validators/index.ts
+++ b/transcendence-app/src/game/validators/index.ts
@@ -1,4 +1,5 @@
 import { registerDecorator } from 'class-validator';
+import { GameMode as GameModetype } from 'pong-engine';
 
 const GAME_COMMANDS = [
   'paddleMoveRight',
@@ -6,6 +7,8 @@ const GAME_COMMANDS = [
   'paddleStop',
   'paddleDrag',
 ];
+
+const GAME_MODES = ['classic', 'shortPaddle', 'misteryZone'];
 
 // https://stackoverflow.com/questions/51528780/typescript-check-typeof-against-custom-type
 type GameCommandType = (typeof GAME_COMMANDS)[number];
@@ -25,6 +28,27 @@ export function IsGameCommand() {
       validator: {
         validate(value: string) {
           return typeof value === 'string' && isGameCommandType(value);
+        },
+      },
+    });
+  };
+}
+
+export const isGameModeType = (value: string): value is GameModetype =>
+  GAME_MODES.includes(value);
+
+export function IsGameMode() {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'IsGameCommand',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: {
+        message: 'The value passed as command is not a valid game command',
+      },
+      validator: {
+        validate(value: string) {
+          return typeof value === 'string' && isGameModeType(value);
         },
       },
     });

--- a/webapp/src/pages/GameRulesPage/GameRulesPage.tsx
+++ b/webapp/src/pages/GameRulesPage/GameRulesPage.tsx
@@ -58,8 +58,17 @@ export default function GameRulesPage() {
           <ol>
             <li>
               <Text variant={TextVariant.PARAGRAPH}>
-                At the start of the game, both players need to click the "Ready"
-                button to indicate they are ready to play.
+                At the start of the game, the player one (the one who joined
+                earlier) will see a list of different game modes to choose from.
+                Once an option is chosen, the game will start once the opponent
+                is ready.
+              </Text>
+            </li>
+            <li>
+              <Text variant={TextVariant.PARAGRAPH}>
+                At the start of the game, the player two (the one who joined
+                later) will have to click a "Ready" button to indicate whether
+                is ready to play.
               </Text>
             </li>
             <li>

--- a/webapp/src/shared/components/Game/Game.css
+++ b/webapp/src/shared/components/Game/Game.css
@@ -15,6 +15,13 @@
   margin: auto;
 }
 
+.game-configuration {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .game-wait {
   margin: auto;
   display: flex;

--- a/webapp/src/shared/components/Game/Game.tsx
+++ b/webapp/src/shared/components/Game/Game.tsx
@@ -169,11 +169,11 @@ const ConfigureGame = ({ submitGameConfig, joinGame }: ConfigureGameProps) => {
     },
     {
       onClick: () => {
-        submitGameConfig('misteryZone');
+        submitGameConfig('mysteryZone');
         joinGame();
       },
-      title: 'Mistery zone',
-      key: 'Mistery zone',
+      title: 'Mystery zone',
+      key: 'Mystery zone',
       iconVariant: IconVariant.ADD,
     },
   ];

--- a/webapp/src/shared/components/Game/hooks/useGameAnimation.tsx
+++ b/webapp/src/shared/components/Game/hooks/useGameAnimation.tsx
@@ -54,10 +54,15 @@ const useGameAnimation = () => {
     );
   }, []);
 
-  const drawMisteryZone = React.useCallback(
+  const drawMysteryZone = React.useCallback(
     (context: CanvasRenderingContext2D) => {
       context.fillStyle = '#191b1f';
-      context.fillRect(0, CANVAS_HEIGHT / 2, CANVAS_WIDTH, MISTERY_ZONE_HEIGH);
+      context.fillRect(
+        0,
+        CANVAS_HEIGHT / 2 - MISTERY_ZONE_HEIGH / 2,
+        CANVAS_WIDTH,
+        MISTERY_ZONE_HEIGH,
+      );
     },
     [],
   );
@@ -138,11 +143,11 @@ const useGameAnimation = () => {
         drawPaddle(canvasContext, paddleRotated);
         drawPaddle(canvasContext, paddleOpponentRotated);
       }
-      if (gameMode === 'misteryZone') {
-        drawMisteryZone(canvasContext);
+      if (gameMode === 'mysteryZone') {
+        drawMysteryZone(canvasContext);
       }
     },
-    [drawBall, drawPaddle, drawMisteryZone],
+    [drawBall, drawPaddle, drawMysteryZone],
   );
 
   return { renderFrame, renderMultiplayerFrame, deltaTimeRef };

--- a/webapp/src/shared/components/Game/hooks/useGameAnimation.tsx
+++ b/webapp/src/shared/components/Game/hooks/useGameAnimation.tsx
@@ -9,8 +9,10 @@ import {
   GameBall,
   GamePaddle,
   GameState,
-  PADDLE_WIDTH,
   PADDLE_HEIGHT,
+  MISTERY_ZONE_HEIGH,
+  GameMode,
+  getPaddleWidth,
 } from 'pong-engine';
 
 const useGameAnimation = () => {
@@ -32,7 +34,12 @@ const useGameAnimation = () => {
   const drawPaddle = React.useCallback(
     (context: CanvasRenderingContext2D, paddle: GamePaddle) => {
       context.fillStyle = paddle.color;
-      context.fillRect(paddle.x, paddle.y, paddle.width, paddle.height);
+      context.fillRect(
+        paddle.x,
+        paddle.y,
+        getPaddleWidth(paddle.short),
+        paddle.height,
+      );
     },
     [],
   );
@@ -46,6 +53,14 @@ const useGameAnimation = () => {
       BRICK_HEIGHT,
     );
   }, []);
+
+  const drawMisteryZone = React.useCallback(
+    (context: CanvasRenderingContext2D) => {
+      context.fillStyle = '#191b1f';
+      context.fillRect(0, CANVAS_HEIGHT / 2, CANVAS_WIDTH, MISTERY_ZONE_HEIGH);
+    },
+    [],
+  );
 
   const getScreenRefreshRate = React.useCallback((): Promise<number> => {
     // We want to calculate how many frames are rendered in one second (fps)
@@ -93,11 +108,11 @@ const useGameAnimation = () => {
       canvasContext: CanvasRenderingContext2D,
       state: GameState,
       isPlayerOne: boolean,
+      gameMode: GameMode | null,
     ) => {
       const ball = state.ball;
       const paddle = state.paddle;
       const paddleOpponent = state.paddleOpponent;
-
       canvasContext.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
       if (isPlayerOne) {
         drawBall(canvasContext, ball);
@@ -111,20 +126,23 @@ const useGameAnimation = () => {
         };
         const paddleRotated = {
           ...paddle,
-          x: CANVAS_WIDTH - paddle.x - PADDLE_WIDTH,
+          x: CANVAS_WIDTH - paddle.x - getPaddleWidth(paddle.short),
           y: CANVAS_HEIGHT - paddle.y - PADDLE_HEIGHT,
         };
         const paddleOpponentRotated = {
           ...paddleOpponent,
-          x: CANVAS_WIDTH - paddleOpponent.x - PADDLE_WIDTH,
+          x: CANVAS_WIDTH - paddleOpponent.x - getPaddleWidth(paddle.short),
           y: CANVAS_HEIGHT - paddleOpponent.y - PADDLE_HEIGHT,
         };
         drawBall(canvasContext, ballRotated);
         drawPaddle(canvasContext, paddleRotated);
         drawPaddle(canvasContext, paddleOpponentRotated);
       }
+      if (gameMode === 'misteryZone') {
+        drawMisteryZone(canvasContext);
+      }
     },
-    [drawBall, drawPaddle],
+    [drawBall, drawPaddle, drawMisteryZone],
   );
 
   return { renderFrame, renderMultiplayerFrame, deltaTimeRef };

--- a/webapp/src/shared/components/Game/hooks/useOnlineGame.tsx
+++ b/webapp/src/shared/components/Game/hooks/useOnlineGame.tsx
@@ -5,6 +5,7 @@ import {
   GameCommand,
   GameInfoClient,
   GameState,
+  GameMode,
 } from 'pong-engine';
 import { useAuth } from '../../../hooks/UseAuth';
 import { useNavigate } from 'react-router-dom';
@@ -24,6 +25,9 @@ const GAME_START_PAUSED = 'gameStartPaused';
 const GAME_START_RESUMED = 'gameStartResumed';
 const GAME_PAUSED = 'gamePaused';
 const GAME_RESUMED = 'gameResumed';
+const CONFIGURE_GAME = 'configureGame';
+const GAME_CONFIG_SUBMIT = 'gameConfigSubmit';
+const MAX_CONNECTION_LAG_IN_MS = 100;
 
 export function useOnlineGame(gameId: string) {
   const { notify, warn } = useNotificationContext();
@@ -33,9 +37,14 @@ export function useOnlineGame(gameId: string) {
   const [isPlayerOne, setIsPlayerOne] = React.useState(true);
   const [onlineGameState, setOnlineGameState] =
     React.useState<GameState | null>(null);
+  const [gameMode, setGameMode] = React.useState<GameMode | null>(null);
   const [gameJoined, setGameJoined] = React.useState(false);
   const [playerOne, setPlayerOne] = React.useState<User | null>(null);
   const [playerTwo, setPlayerTwo] = React.useState<User | null>(null);
+  const [isGamePaused, setIsGamePaused] = React.useState<boolean>(false);
+  const [shouldConfigureGame, setShouldConfigureGame] =
+    React.useState<boolean>(false);
+  const updateTimestamp = React.useRef<number | undefined>();
 
   const sendGameCommand = React.useCallback(
     (command: GameCommand, payload?: DragPayload) => {
@@ -55,6 +64,16 @@ export function useOnlineGame(gameId: string) {
       socket.emit(JOIN_GAME, { gameRoomId: gameId });
     }
   }, [gameId, gameJoined]);
+
+  const submitGameConfig = React.useCallback(
+    (gameMode: GameMode) => {
+      if (shouldConfigureGame) {
+        socket.emit(GAME_CONFIG_SUBMIT, { gameRoomId: gameId, gameMode });
+        setShouldConfigureGame(false);
+      }
+    },
+    [gameId, shouldConfigureGame],
+  );
 
   React.useEffect(() => {
     let timeoutId: NodeJS.Timeout | undefined;
@@ -79,7 +98,14 @@ export function useOnlineGame(gameId: string) {
     }
 
     function handleUpdateGame(info: GameInfoClient) {
+      const now = Date.now();
+      if (updateTimestamp.current) {
+        now - updateTimestamp.current > MAX_CONNECTION_LAG_IN_MS &&
+          warn('slow connection', 'top');
+        updateTimestamp.current = now;
+      }
       setOnlineGameState(info.gameState);
+      setGameMode(info.gameMode);
     }
 
     function handleGameNotFound() {
@@ -95,19 +121,27 @@ export function useOnlineGame(gameId: string) {
     }
 
     function handleGameStartPaused() {
+      setIsGamePaused(true);
       notify('Waiting for players to join');
     }
 
     function handleGameStartResumed() {
+      setIsGamePaused(false);
       notify('Game starting soon');
     }
 
     function handleGamePaused() {
+      setIsGamePaused(true);
       notify('Game paused');
     }
 
     function handleGameResumed() {
+      setIsGamePaused(false);
       notify('Game resuming soon');
+    }
+
+    function handleGameConfigure() {
+      setShouldConfigureGame(true);
     }
 
     socket.on(GAME_JOINED, handleGameJoined);
@@ -118,6 +152,7 @@ export function useOnlineGame(gameId: string) {
     socket.on(GAME_START_RESUMED, handleGameStartResumed);
     socket.on(GAME_PAUSED, handleGamePaused);
     socket.on(GAME_RESUMED, handleGameResumed);
+    socket.on(CONFIGURE_GAME, handleGameConfigure);
 
     return () => {
       socket.emit(LEAVE_GAME, { gameRoomId: gameId });
@@ -150,5 +185,9 @@ export function useOnlineGame(gameId: string) {
     sendGameCommand,
     playerOne,
     playerTwo,
+    isGamePaused,
+    shouldConfigureGame,
+    submitGameConfig,
+    gameMode,
   };
 }

--- a/webapp/src/shared/context/NotificationContext.tsx
+++ b/webapp/src/shared/context/NotificationContext.tsx
@@ -6,7 +6,7 @@ const NOTIFICATION_SPAN_MS = 4000;
 
 type Context = {
   notify: (message: any) => void;
-  warn: (message: any) => void;
+  warn: (message: any, position?: SnackbarPosition) => void;
   hide: () => void;
 };
 
@@ -43,7 +43,7 @@ export const NotificationContextProvider = ({
     }
   }, []);
 
-  const warn = React.useCallback((arg: any) => {
+  const warn = React.useCallback((arg: any, position?: SnackbarPosition) => {
     if (arg) {
       let message: string;
       if (typeof arg === 'object') {
@@ -52,7 +52,11 @@ export const NotificationContextProvider = ({
         message = String(arg);
       }
       if (message.length) {
-        setNotification({ message, type: 'warning', position: 'bottom' });
+        setNotification({
+          message,
+          type: 'warning',
+          position: position ?? 'bottom',
+        });
         setVisible(true);
       }
     }


### PR DESCRIPTION
closes #558 
closes #506
closes #492

This PR implements the mechanism (frontend and backend) to run different types of games. It includes classic, misteryZone (black area in the middle of the court) and short paddles. More could be done but this was good for this PR

❗ Also, I've included an upgrade to 60FPS to the backend server and an alert which displays a snackbar if we have a lag bigger than 100ms to warn users about their bad connection. I'm closing for now #492 since the idea of that ticket was to reflect subject's requirements, but we can open an exploratory ticket to investigate how to improve online gaming experience as we talked.