### PR TITLE
#386 fix express adapter premature close error

### DIFF
--- a/transcendence-app/src/main.ts
+++ b/transcendence-app/src/main.ts
@@ -4,9 +4,12 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { setupApp } from './setup-app';
+import { TranscendenceLogger } from './shared/utils';
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    logger: new TranscendenceLogger(),
+  });
   app.enable('trust proxy');
   app.setGlobalPrefix('api');
   app.enableVersioning({
@@ -23,4 +26,5 @@ async function bootstrap() {
   SwaggerModule.setup('api', app, document);
   await app.listen(3000);
 }
+
 bootstrap();

--- a/transcendence-app/src/shared/utils.ts
+++ b/transcendence-app/src/shared/utils.ts
@@ -1,3 +1,5 @@
+import { ConsoleLogger } from '@nestjs/common';
+
 export function loadEsmModule<T>(modulePath: string): Promise<T> {
   return Function(
     'modulePath',
@@ -11,4 +13,13 @@ export function removeDoubleQuotes(string: string) {
 
 export function capitalizeFirstLetter(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+export class TranscendenceLogger extends ConsoleLogger {
+  error(message: any, stack?: string, context?: string) {
+    if (context === 'ExpressAdapter' && message === 'Premature close') {
+      return;
+    }
+    super.error(message, stack, context);
+  }
 }

--- a/transcendence-app/src/shared/utils.ts
+++ b/transcendence-app/src/shared/utils.ts
@@ -17,6 +17,16 @@ export function capitalizeFirstLetter(string: string) {
 
 export class TranscendenceLogger extends ConsoleLogger {
   error(message: any, stack?: string, context?: string) {
+    /**
+     * When using StreamableFile to stream user avatars efficiently, it's
+     * possible for clients to prematurely close the connection while the
+     * server is streaming the file. This can trigger a 'Premature close'
+     * error in Node.js. However, this behavior is expected and does not
+     * indicate a server error. To minimize false error noise and improve
+     * overall system reliability, we've disabled this error in our Console
+     * logger class.
+     *
+     */
     if (context === 'ExpressAdapter' && message === 'Premature close') {
       return;
     }


### PR DESCRIPTION
As explained in #386, ever since we updated node we have continuosly an error log line when we attempt to stream avatar files. This has no functional impact, but the error log has to be handled. This is the handling of those log lines.
close #386